### PR TITLE
핫픽스

### DIFF
--- a/pages/index.js
+++ b/pages/index.js
@@ -164,6 +164,7 @@ export default function Home() {
               className="text-blue-500"
               href="https://github.com/kirk0201"
               target="_blank"
+              rel="noreferrer"
             >
               github.com/kirk0201
             </a>


### PR DESCRIPTION
링크 옵션 target="_blank"는 보안 위험이 있으므로 rel='noreferrer' 추가